### PR TITLE
Use --no-fail when --dockerfile=warn

### DIFF
--- a/lint-install.go
+++ b/lint-install.go
@@ -204,11 +204,12 @@ func shellLintCmd(_ string, level string) string {
 
 // dockerLintCmd returns the appropriate docker lint command for a project.
 func dockerLintCmd(_ string, level string) string {
-	threshold := "info"
+	f := ""
 	if level == "warn" {
-		threshold = "none"
+		f = " --no-fail "
 	}
-	return fmt.Sprintf(`out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) -t %s $(shell find . -name "*Dockerfile")`, threshold)
+
+	return fmt.Sprintf(`out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)%s$(shell find . -name "*Dockerfile")`, f)
 }
 
 // main creates peanut butter & jelly sandwiches with utmost precision.


### PR DESCRIPTION
This fixes a bug where --dockerfile=warn still exits with error code 1, by using the correct flag.
