### PR TITLE
Fix module detection bugs within golangci-lint invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(LINT_OS),Darwin)
 endif
 
 LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
-GOLINT_CONFIG:=$(shell dirname $(LINT_ROOT)/.golangci.yml)
+GOLINT_CONFIG:=$(LINT_ROOT)/.golangci.yml
 
 lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ HADOLINT_VERSION ?= v2.7.0
 SHELLCHECK_VERSION ?= v0.7.2
 LINT_OS := $(shell uname)
 LINT_ARCH := $(shell uname -m)
+LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
 ifeq ($(LINT_OS),Darwin)
@@ -16,7 +17,7 @@ ifeq ($(LINT_OS),Darwin)
 endif
 
 LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
-GOLINT_CONFIG:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/.golangci.yml
+GOLINT_CONFIG:=$(shell dirname $(LINT_ROOT)/.golangci.yml)
 
 lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -7,6 +7,7 @@
 {{ if .Shell}}SHELLCHECK_VERSION ?= v0.7.2{{ end }}
 LINT_OS := $(shell uname)
 LINT_ARCH := $(shell uname -m)
+LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
 ifeq ($(LINT_OS),Darwin)
@@ -16,7 +17,7 @@ ifeq ($(LINT_OS),Darwin)
 endif
 
 {{ if .Shell }}LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]'){{ end }}
-{{ if .Go }}GOLINT_CONFIG:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/.golangci.yml{{ end }}
+{{ if .Go }}GOLINT_CONFIG:=$(LINT_ROOT)/.golangci.yml{{ end }}
 
 lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH){{ end }}
 	{{- range .Commands }}

--- a/lint-install.go
+++ b/lint-install.go
@@ -186,11 +186,12 @@ func goLintCmd(root string, level string) string {
 		suffix = " || true"
 	}
 
-	if len(found) == 1 && found[0] == root {
+	klog.Infof("found %d modules within %s: %s", len(found), root, found)
+	if len(found) == 0 || (len(found) == 1 && found[0] == strings.Trim(root, "/")) {
 		return fmt.Sprintf("out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run%s", suffix)
 	}
 
-	return fmt.Sprintf(`find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && golangci-lint run -c $(GOLINT_CONFIG)"%s`, suffix)
+	return fmt.Sprintf(`find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run -c $(GOLINT_CONFIG)"%s`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.

--- a/lint-install.go
+++ b/lint-install.go
@@ -191,7 +191,7 @@ func goLintCmd(root string, level string) string {
 		return fmt.Sprintf("out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run%s", suffix)
 	}
 
-	return fmt.Sprintf(`find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run -c $(GOLINT_CONFIG)"%s`, suffix)
+	return fmt.Sprintf(`find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && $(LINT_ROOT)/out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run -c $(GOLINT_CONFIG)"%s`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.

--- a/lint-install.go
+++ b/lint-install.go
@@ -193,7 +193,7 @@ func goLintCmd(root string, level string, fix bool) string {
 		return fmt.Sprintf("out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run%s", suffix)
 	}
 
-	return fmt.Sprintf(`find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && $(LINT_ROOT)/out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run -c $(GOLINT_CONFIG)"%s`, suffix)
+	return fmt.Sprintf(`find . -name go.mod -execdir "$(LINT_ROOT)/out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.


### PR DESCRIPTION
Fixes the following bugs:

* If only 1 go module was found, it selected the multi-module invocation method as the root directory had a trailing slash.
* If no go modules were found, the multi-module complicated invocation method was used, when it wasn't necessary
* multi-module invocation method wasn't using the locally built golangci-lint, leading to version mismatches
  