### PR TITLE
hadolint: Use --no-fail instead of -t info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GOLINT_CONFIG:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/.golan
 
 lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
-	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) -t info $(shell find . -name "*Dockerfile")
+	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) $(shell find . -name "*Dockerfile")
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
 
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:

--- a/lint-install.go
+++ b/lint-install.go
@@ -204,11 +204,12 @@ func shellLintCmd(_ string, level string) string {
 
 // dockerLintCmd returns the appropriate docker lint command for a project.
 func dockerLintCmd(_ string, level string) string {
-	threshold := "info"
+	f := ""
 	if level == "warn" {
-		threshold = "none"
+		f = " --no-fail"
 	}
-	return fmt.Sprintf(`out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) -t %s $(shell find . -name "*Dockerfile")`, threshold)
+
+	return fmt.Sprintf(`out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)%s $(shell find . -name "*Dockerfile")`, f)
 }
 
 // main creates peanut butter & jelly sandwiches with utmost precision.


### PR DESCRIPTION
The intent was that if `--dockerfile=warn`, that hadolint would not fail.

Unfortunately, -t info still exited with a non-zero code. --no-fail yields the correct behavior.