### PR TITLE
Exclude forcetypeassert and noctx checks from test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -173,10 +173,12 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
-        - gocyclo
-        - errcheck
         - dupl
+        - errcheck
+        - forcetypeassert
+        - gocyclo
         - gosec
+        - noctx
 
     - path: cmd.*
       linters:


### PR DESCRIPTION
`noctx` and `forcetypeassert` checks mostly serve to catch unexpected production runtime faults, and are raise lint issues that aren't necessary to resolve in tests. For instance:

```
http-server/http_server_test.go:276:31: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
			req, err := http.NewRequest("GET", test.url, nil)
```

and:

```
packet_test.go:372:3: type assertion must be checked (forcetypeassert)
		px := p.(*packetOACK)
		^
```

Rather than generate extra work for coders and reviewers, I think we should turn these checks off for tests where they are unlikely to ever generate unexpected behavior.
