### PR TITLE
Disable noctx/deep-exit in *cmd*

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -180,7 +180,7 @@ issues:
         - gosec
         - noctx
 
-    - path: cmd.*
+    - path: .*cmd.*
       linters:
         - noctx
 
@@ -188,7 +188,7 @@ issues:
       linters:
         - noctx
 
-    - path: cmd.*
+    - path: .*cmd.*
       text: "deep-exit"
 
     - path: main\.go


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@stromberg.org>

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
