### PR TITLE
Extend golangci-lint timeout from 1m to 4m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  # The default runtime timeout is 1m, which doesn't work well on Github Actions.
+  timeout: 4m
+
 # NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
 linters-settings:
   cyclop:


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@stromberg.org>

## Description

Address problem raised by tink: https://github.com/tinkerbell/tink/pull/538/checks?check_run_id=3678441886

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
