### PR TITLE
Update golangci-lint to v1.42.1, enable errname

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,8 +107,7 @@ linters:
     - dupl
     - durationcheck
     - errcheck
-    # errname is only available in golangci-lint v1.42.0+ - wait until v1.43 is available to settle
-    # - errname
+    - errname
     - errorlint
     - exhaustive
     - exportloopref

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # BEGIN: lint-install .
 # http://github.com/tinkerbell/lint-install
 
-GOLINT_VERSION ?= v1.42.0
+GOLINT_VERSION ?= v1.42.1
 HADOLINT_VERSION ?= v2.7.0
 SHELLCHECK_VERSION ?= v0.7.2
 YAMLLINT_VERSION ?= 1.26.3


### PR DESCRIPTION
v1.42.1 has been out for over a month, so let's upgrade to it and enable errname. :)
