### PR TITLE
Use pip3 to install yamllint instead of setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/l
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
 	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) $(shell find . -name "*Dockerfile")
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
-	PYTHONPATH=$(YAMLLINT_ROOT)/lib $(YAMLLINT_ROOT)/bin/yamllint .
+	PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint .
 
 fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run --fix
@@ -47,7 +47,6 @@ out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 
 $(YAMLLINT_ROOT)/bin/yamllint:
-	mkdir -p $(YAMLLINT_ROOT)/lib
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
-	cd $(YAMLLINT_ROOT) && PYTHONPATH=lib python setup.py -q install --prefix . --install-lib lib
+	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
 # END: lint-install .

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -53,9 +53,8 @@ out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 
 {{ if .YAML -}}
 $(YAMLLINT_ROOT)/bin/yamllint:
-	mkdir -p $(YAMLLINT_ROOT)/lib
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
-	cd $(YAMLLINT_ROOT) && PYTHONPATH=lib python setup.py -q install --prefix . --install-lib lib
+	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
 {{ end -}}
 
 # END: lint-install {{.Args}}

--- a/lint-install.go
+++ b/lint-install.go
@@ -234,7 +234,7 @@ func yamlLintCmd(_ string, level string) string {
 	if level == "warn" {
 		suffix = " || true"
 	}
-	return fmt.Sprintf(`PYTHONPATH=$(YAMLLINT_ROOT)/lib $(YAMLLINT_ROOT)/bin/yamllint .%s`, suffix)
+	return fmt.Sprintf(`PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint .%s`, suffix)
 }
 
 // main creates peanut butter & jelly sandwiches with utmost precision.


### PR DESCRIPTION
This PR ensures that Python 3 is used rather than Python <something>.

It fixes the following error I've been getting using yamllint on macOS 11.5.2, where the default `python` interpreter is Python 2.7.16 (no longer supported).

```
% make lint
mkdir -p out/linters/yamllint-1.26.3/lib
curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v1.26.3.tar.gz | tar -C out/linters -zxf -
cd out/linters/yamllint-1.26.3 && PYTHONPATH=lib python setup.py -q install --prefix . --install-lib lib
zip_safe flag not set; analyzing archive contents...
yamllint.config: module references __file__
Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    license=__license__,
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 418, in run
    self.easy_install(spec, not self.no_deps)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 660, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 707, in install_item
    self.process_distribution(spec, dist, deps)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 752, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 782, in resolve
    replace_conflicting=replace_conflicting
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 1065, in best_match
    return self.obtain(req, installer)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 1077, in obtain
    return installer(requirement)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 679, in easy_install
    return self.install_item(spec, dist.location, tmpdir, deps)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 705, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 890, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 1158, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/command/easy_install.py", line 1144, in run_setup
    run_setup(setup_script, args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 253, in run_setup
    raise
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 166, in save_modules
    saved_exc.resume()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 141, in resume
    six.reraise(type, exc, self._tb)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 154, in save_modules
    yield saved
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 250, in run_setup
    _execfile(setup_script, ns)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/setuptools/sandbox.py", line 45, in _execfile
    exec(code, globals, locals)
  File "/var/folders/w4/c80p80p90r53jh1hbk7cx7pw0000gp/T/easy_install-Vu7tZ_/PyYAML-6.0b1/setup.py", line 67, in <module>

ImportError: No module named pathlib
make: *** [out/linters/yamllint-1.26.3/bin/yamllint] Error 1
make: *** Deleting file `out/linters/yamllint-1.26.3/bin/yamllint'
```

