### PR TITLE
Avoid useless yamllint downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
 YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
 
 .PHONY: lint
-lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/bin/yamllint
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
 	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) $(shell find . -name "*Dockerfile")
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
@@ -51,7 +51,7 @@ out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
 	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 
-$(YAMLLINT_ROOT)/bin/yamllint:
+$(YAMLLINT_ROOT)/dist/bin/yamllint:
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -22,7 +22,7 @@ endif
 {{ if .YAML }}YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION){{ end }}
 
 .PHONY: lint
-lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/bin/yamllint{{ end }}
+lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
 	{{- range .LintCommands }}
 	{{ .}}{{ end}}
 
@@ -57,7 +57,7 @@ out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 {{ end -}}
 
 {{ if .YAML -}}
-$(YAMLLINT_ROOT)/bin/yamllint:
+$(YAMLLINT_ROOT)/dist/bin/yamllint:
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -


### PR DESCRIPTION
## Description
 
- [x] Fix make dependency for the yamllint script.
- [x] Ensure yamllint install will work by ensuring out/lint dir exists.
- [x] Keep only the current lint versions around in out/lint

## Why is this needed

Mostly to avoid make re-downloading/re-installing yamllint, but also ensures yamllint will install correctly if yaml is the only language detected. I originally thought I was running into multiple versions of yamllint and thus added the `rm` part, which was not the case but I think it makes sense to keep it anyway.

## How Has This Been Tested?

Manually ran `make lint` and verified that yamllint isn't re-installed every time after my change was added.

main:
```
[17:42:29]-[~/go/src/github.com/tinkerbell/lint-install]─[manny@nixc3small]> 
rm -rf out/linters/
                                                                                                                                                                                      
[17:42:30]-[~/go/src/github.com/tinkerbell/lint-install]─[manny@nixc3small]> 
make lint
mkdir -p out/linters
mkdir -p out/linters
mkdir -p out/linters
curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v1.26.3.tar.gz | tar -C out/linters -zxf -
curl -sSfL https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-v0.7.2.linux.x86_64.tar.xz | tar -C out/linters -xJf -
curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-Linux-x86_64 > out/linters/hadolint-v2.7.0-x86_64
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters v1.42.1
golangci/golangci-lint info checking GitHub for tag 'v1.42.1'
golangci/golangci-lint info found version: 1.42.1 for v1.42.1/linux/amd64
cd out/linters/yamllint-1.26.3 && pip3 install . -t dist
mv out/linters/shellcheck-v0.7.2 out/linters/shellcheck-v0.7.2-x86_64
golangci/golangci-lint info installed out/linters/golangci-lint
mv out/linters/golangci-lint out/linters/golangci-lint-v1.42.1-x86_64
chmod u+x out/linters/hadolint-v2.7.0-x86_64
Processing /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
Collecting pathspec>=0.5.3
  Using cached pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
Collecting pyyaml
  Using cached PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
Collecting setuptools
  Using cached setuptools-58.2.0-py3-none-any.whl (946 kB)
Using legacy 'setup.py install' for yamllint, since package 'wheel' is not installed.
Installing collected packages: setuptools, pyyaml, pathspec, yamllint
    Running setup.py install for yamllint ... done
Successfully installed pathspec-0.9.0 pyyaml-5.4.1 setuptools-58.2.0 yamllint-1.26.3
WARNING: You are using pip version 21.1.3; however, version 21.3 is available.
You should consider upgrading via the '/nix/store/97w52ckcjnfiz89h3lh7zf1kysgfm2s8-python3-3.9.6/bin/python3.9 -m pip install --upgrade pip' command.
out/linters/golangci-lint-v1.42.1-x86_64 run
out/linters/hadolint-v2.7.0-x86_64 ./test/test.Dockerfile
out/linters/shellcheck-v0.7.2-x86_64/shellcheck ./test/test.sh
PYTHONPATH=out/linters/yamllint-1.26.3/dist out/linters/yamllint-1.26.3/dist/bin/yamllint .
                                                                                                                                                                                      
[17:42:33]-[~/go/src/github.com/tinkerbell/lint-install]─[manny@nixc3small]> 
make lint
curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v1.26.3.tar.gz | tar -C out/linters -zxf -
cd out/linters/yamllint-1.26.3 && pip3 install . -t dist
Processing /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
Collecting pathspec>=0.5.3
  Using cached pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
Collecting pyyaml
  Using cached PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
Collecting setuptools
  Using cached setuptools-58.2.0-py3-none-any.whl (946 kB)
Using legacy 'setup.py install' for yamllint, since package 'wheel' is not installed.
Installing collected packages: setuptools, pyyaml, pathspec, yamllint
    Running setup.py install for yamllint ... done
Successfully installed pathspec-0.9.0 pyyaml-5.4.1 setuptools-58.2.0 yamllint-1.26.3
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/yamllint-1.26.3-py3.9.egg-info already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/yamllint already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/pathspec-0.9.0.dist-info already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/pathspec already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/_yaml already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/yaml already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/PyYAML-5.4.1.dist-info already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/setuptools-58.2.0.dist-info already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/setuptools already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/pkg_resources already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/_distutils_hack already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/distutils-precedence.pth already exists. Specify --upgrade to force replacement.
WARNING: Target directory /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3/dist/bin already exists. Specify --upgrade to force replacement.
WARNING: You are using pip version 21.1.3; however, version 21.3 is available.
You should consider upgrading via the '/nix/store/97w52ckcjnfiz89h3lh7zf1kysgfm2s8-python3-3.9.6/bin/python3.9 -m pip install --upgrade pip' command.
out/linters/golangci-lint-v1.42.1-x86_64 run
out/linters/hadolint-v2.7.0-x86_64 ./test/test.Dockerfile
out/linters/shellcheck-v0.7.2-x86_64/shellcheck ./test/test.sh
PYTHONPATH=out/linters/yamllint-1.26.3/dist out/linters/yamllint-1.26.3/dist/bin/yamllint .
```
my branch:
```
[17:42:57]-[~/go/src/github.com/tinkerbell/lint-install]─[manny@nixc3small]> 
rm -rf out/linters/
                                                                                                                                                                                      
[17:42:59]-[~/go/src/github.com/tinkerbell/lint-install]─[manny@nixc3small]> 
make lint
mkdir -p out/linters
mkdir -p out/linters
mkdir -p out/linters
mkdir -p out/linters
rm -rf out/linters/shellcheck-*
rm -rf out/linters/hadolint-*
rm -rf out/linters/golangci-lint-*
rm -rf out/linters/yamllint-*
curl -sSfL https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-v0.7.2.linux.x86_64.tar.xz | tar -C out/linters -xJf -
curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-Linux-x86_64 > out/linters/hadolint-v2.7.0-x86_64
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters v1.42.1
curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v1.26.3.tar.gz | tar -C out/linters -zxf -
golangci/golangci-lint info checking GitHub for tag 'v1.42.1'
chmod u+x out/linters/hadolint-v2.7.0-x86_64
cd out/linters/yamllint-1.26.3 && pip3 install . -t dist
mv out/linters/shellcheck-v0.7.2 out/linters/shellcheck-v0.7.2-x86_64
golangci/golangci-lint info found version: 1.42.1 for v1.42.1/linux/amd64
Processing /home/manny/go/src/github.com/tinkerbell/lint-install/out/linters/yamllint-1.26.3
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
golangci/golangci-lint info installed out/linters/golangci-lint
mv out/linters/golangci-lint out/linters/golangci-lint-v1.42.1-x86_64
Collecting pathspec>=0.5.3
  Using cached pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
Collecting pyyaml
  Using cached PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
Collecting setuptools
  Using cached setuptools-58.2.0-py3-none-any.whl (946 kB)
Using legacy 'setup.py install' for yamllint, since package 'wheel' is not installed.
Installing collected packages: setuptools, pyyaml, pathspec, yamllint
    Running setup.py install for yamllint ... done
Successfully installed pathspec-0.9.0 pyyaml-5.4.1 setuptools-58.2.0 yamllint-1.26.3
WARNING: You are using pip version 21.1.3; however, version 21.3 is available.
You should consider upgrading via the '/nix/store/97w52ckcjnfiz89h3lh7zf1kysgfm2s8-python3-3.9.6/bin/python3.9 -m pip install --upgrade pip' command.
out/linters/golangci-lint-v1.42.1-x86_64 run
out/linters/hadolint-v2.7.0-x86_64 ./test/test.Dockerfile
out/linters/shellcheck-v0.7.2-x86_64/shellcheck ./test/test.sh
PYTHONPATH=out/linters/yamllint-1.26.3/dist out/linters/yamllint-1.26.3/dist/bin/yamllint .
                                                                                                                                                                                      
[17:43:03]-[~/go/src/github.com/tinkerbell/lint-install]─[manny@nixc3small]> 
make lint
out/linters/golangci-lint-v1.42.1-x86_64 run
out/linters/hadolint-v2.7.0-x86_64 ./test/test.Dockerfile
out/linters/shellcheck-v0.7.2-x86_64/shellcheck ./test/test.sh
PYTHONPATH=out/linters/yamllint-1.26.3/dist out/linters/yamllint-1.26.3/dist/bin/yamllint .
```

## How are existing users impacted? What migration steps/scripts do we need?

Faster linting, less network wasted.
