### PR TITLE
Allow linters to run concurrently

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+has nix && use nix
+dotenv_if_exists
+PATH_add bin
+path_add GOBIN bin

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@
 .PHONY: lint
 lint: _lint
 
-GOLINT_VERSION ?= v1.42.1
-HADOLINT_VERSION ?= v2.7.0
-SHELLCHECK_VERSION ?= v0.7.2
-YAMLLINT_VERSION ?= 1.26.3
 LINT_ARCH := $(shell uname -m)
 LINT_OS := $(shell uname)
 LINT_OS_LOWER := $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
@@ -21,27 +17,31 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
-GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
-YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
 
+SHELLCHECK_VERSION ?= v0.7.2
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
 	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 
+HADOLINT_VERSION ?= v2.7.0
 out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/hadolint-*
 	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 
+GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+GOLINT_VERSION ?= v1.42.1
 out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
 	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 
+YAMLLINT_VERSION ?= 1.26.3
+YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
 $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ GOLINT_VERSION ?= v1.42.1
 HADOLINT_VERSION ?= v2.7.0
 SHELLCHECK_VERSION ?= v0.7.2
 YAMLLINT_VERSION ?= 1.26.3
-LINT_OS := $(shell uname)
 LINT_ARCH := $(shell uname -m)
+LINT_OS := $(shell uname)
+LINT_OS_LOWER := $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
 LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
@@ -17,7 +18,6 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
-LINT_LOWER_OS = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
 GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
 YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
 
@@ -36,7 +36,7 @@ fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/li
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
-	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
 	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 
 out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,12 @@ endif
 
 
 SHELLCHECK_VERSION ?= v0.7.2
-out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
+out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
-	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
 
 HADOLINT_VERSION ?= v2.7.0
 out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
@@ -48,15 +49,15 @@ $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
 .PHONY: _lint
-_lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
+_lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
 	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run
 	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) $(shell find . -name "*Dockerfile")
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) $(shell find . -name "*.sh")
 	PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint .
 
 .PHONY: fix
-fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
+fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run --fix
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
 # END: lint-install .

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
+LINTERS :=
+FIXERS :=
+
 SHELLCHECK_VERSION ?= v0.7.2
 SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 $(SHELLCHECK_BIN):
@@ -25,6 +28,15 @@ $(SHELLCHECK_BIN):
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
 	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@
 	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
+
+LINTERS += shellcheck-lint
+shellcheck-lint: $(SHELLCHECK_BIN)
+	$(SHELLCHECK_BIN) $(shell find . -name "*.sh")
+
+FIXERS += shellcheck-fix
+shellcheck-fix: $(SHELLCHECK_BIN)
+	$(SHELLCHECK_BIN) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
+
 HADOLINT_VERSION ?= v2.7.0
 HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 $(HADOLINT_BIN):
@@ -32,6 +44,11 @@ $(HADOLINT_BIN):
 	rm -rf out/linters/hadolint-*
 	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > $@
 	chmod u+x $@
+
+LINTERS += hadolint-lint
+hadolint-lint: $(HADOLINT_BIN)
+	$(HADOLINT_BIN) $(shell find . -name "*Dockerfile")
+
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.42.1
 GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
@@ -40,6 +57,15 @@ $(GOLANGCI_LINT_BIN):
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
 	mv out/linters/golangci-lint $@
+
+LINTERS += golangci-lint-lint
+golangci-lint-lint: $(GOLANGCI_LINT_BIN)
+	$(GOLANGCI_LINT_BIN) run
+
+FIXERS += golangci-lint-fix
+golangci-lint-fix: $(GOLANGCI_LINT_BIN)
+	$(GOLANGCI_LINT_BIN) run --fix
+
 YAMLLINT_VERSION ?= 1.26.3
 YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
 YAMLLINT_BIN := $(YAMLLINT_ROOT)/dist/bin/yamllint
@@ -48,16 +74,15 @@ $(YAMLLINT_BIN):
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install --target dist .
-.PHONY: _lint
-_lint: $(SHELLCHECK_BIN) $(HADOLINT_BIN) $(GOLANGCI_LINT_BIN) $(YAMLLINT_BIN)
-	$(GOLANGCI_LINT_BIN) run
-	$(HADOLINT_BIN) $(shell find . -name "*Dockerfile")
-	$(SHELLCHECK_BIN) $(shell find . -name "*.sh")
+
+LINTERS += yamllint-lint
+yamllint-lint: $(YAMLLINT_BIN)
 	PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint .
 
-.PHONY: fix
-fix: $(SHELLCHECK_BIN) $(GOLANGCI_LINT_BIN)
-	$(GOLANGCI_LINT_BIN) run --fix
-	$(SHELLCHECK_BIN) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
+.PHONY: _lint $(LINTERS)
+_lint: $(LINTERS)
+
+.PHONY: fix $(FIXERS)
+fix: $(FIXERS)
 
 # END: lint-install .

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 
-GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
-GOLINT_VERSION ?= v1.42.1
-out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+GOLANGCI_LINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+GOLANGCI_LINT_VERSION ?= v1.42.1
+out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
-	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 
 YAMLLINT_VERSION ?= 1.26.3
 YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
@@ -48,15 +48,15 @@ $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
 .PHONY: _lint
-_lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
-	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
+_lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
+	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run
 	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) $(shell find . -name "*Dockerfile")
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
 	PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint .
 
 .PHONY: fix
-fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
-	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run --fix
+fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run --fix
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
 # END: lint-install .

--- a/Makefile
+++ b/Makefile
@@ -17,37 +17,33 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
-
 SHELLCHECK_VERSION ?= v0.7.2
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
-	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@
 	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
-
 HADOLINT_VERSION ?= v2.7.0
 out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/hadolint-*
-	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
-	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
-
-GOLANGCI_LINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > $@
+	chmod u+x $@
+GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.42.1
 out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
-	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
-
+	mv out/linters/golangci-lint $@
 YAMLLINT_VERSION ?= 1.26.3
-YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
+YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
 $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
-	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
+	cd $(YAMLLINT_ROOT) && pip3 install --target dist .
 .PHONY: _lint
 _lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
 	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/l
 .PHONY: fix
 fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
 	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run --fix
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh") -f diff | git apply -p2 -
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 	mkdir -p out/linters

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 LINTERS :=
 FIXERS :=
 
-SHELLCHECK_VERSION ?= v0.7.2
+SHELLCHECK_VERSION ?= v0.8.0
 SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 $(SHELLCHECK_BIN):
 	mkdir -p out/linters
@@ -37,7 +37,7 @@ FIXERS += shellcheck-fix
 shellcheck-fix: $(SHELLCHECK_BIN)
 	$(SHELLCHECK_BIN) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
-HADOLINT_VERSION ?= v2.7.0
+HADOLINT_VERSION ?= v2.8.0
 HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 $(HADOLINT_BIN):
 	mkdir -p out/linters
@@ -50,7 +50,7 @@ hadolint-lint: $(HADOLINT_BIN)
 	$(HADOLINT_BIN) $(shell find . -name "*Dockerfile")
 
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.42.1
+GOLANGCI_LINT_VERSION ?= v1.43.0
 GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p out/linters

--- a/Makefile
+++ b/Makefile
@@ -18,42 +18,46 @@ ifeq ($(LINT_OS),Darwin)
 endif
 
 SHELLCHECK_VERSION ?= v0.7.2
-out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
+SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+$(SHELLCHECK_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
 	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@
 	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
 HADOLINT_VERSION ?= v2.7.0
-out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
+HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+$(HADOLINT_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/hadolint-*
 	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > $@
 	chmod u+x $@
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.42.1
-out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
+GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
+$(GOLANGCI_LINT_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
 	mv out/linters/golangci-lint $@
 YAMLLINT_VERSION ?= 1.26.3
 YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
-$(YAMLLINT_ROOT)/dist/bin/yamllint:
+YAMLLINT_BIN := $(YAMLLINT_ROOT)/dist/bin/yamllint
+$(YAMLLINT_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install --target dist .
 .PHONY: _lint
-_lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) $(YAMLLINT_ROOT)/dist/bin/yamllint
-	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run
-	out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) $(shell find . -name "*Dockerfile")
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) $(shell find . -name "*.sh")
+_lint: $(SHELLCHECK_BIN) $(HADOLINT_BIN) $(GOLANGCI_LINT_BIN) $(YAMLLINT_BIN)
+	$(GOLANGCI_LINT_BIN) run
+	$(HADOLINT_BIN) $(shell find . -name "*Dockerfile")
+	$(SHELLCHECK_BIN) $(shell find . -name "*.sh")
 	PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint .
 
 .PHONY: fix
-fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
-	out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run --fix
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
+fix: $(SHELLCHECK_BIN) $(GOLANGCI_LINT_BIN)
+	$(GOLANGCI_LINT_BIN) run --fix
+	$(SHELLCHECK_BIN) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
 # END: lint-install .

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -6,8 +6,9 @@
 {{ if .Dockerfile}}HADOLINT_VERSION ?= v2.7.0{{ end }}
 {{ if .Shell}}SHELLCHECK_VERSION ?= v0.7.2{{ end }}
 {{ if .YAML}}YAMLLINT_VERSION ?= 1.26.3{{ end }}
-LINT_OS := $(shell uname)
 LINT_ARCH := $(shell uname -m)
+LINT_OS := $(shell uname)
+LINT_OS_LOWER := $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
 LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
@@ -17,7 +18,6 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
-{{ if .Shell }}LINT_LOWER_OS = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]'){{ end }}
 {{ if .Go }}GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml{{ end }}
 {{ if .YAML }}YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION){{ end }}
 
@@ -35,7 +35,7 @@ fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/sh
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
-	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
 	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 
 {{ end -}}

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -17,6 +17,9 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
+LINTERS :=
+FIXERS :=
+
 {{ if .Shell -}}
 SHELLCHECK_VERSION ?= v0.7.2
 SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
@@ -26,6 +29,15 @@ $(SHELLCHECK_BIN):
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
 	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@
 	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
+
+LINTERS += shellcheck-lint
+shellcheck-lint: $(SHELLCHECK_BIN)
+	{{ .LintCommands.shellcheck }}
+
+FIXERS += shellcheck-fix
+shellcheck-fix: $(SHELLCHECK_BIN)
+	{{ .FixCommands.shellcheck }}
+
 {{ end -}}
 
 {{ if .Dockerfile -}}
@@ -36,6 +48,11 @@ $(HADOLINT_BIN):
 	rm -rf out/linters/hadolint-*
 	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > $@
 	chmod u+x $@
+
+LINTERS += hadolint-lint
+hadolint-lint: $(HADOLINT_BIN)
+	{{ .LintCommands.hadolint }}
+
 {{ end -}}
 
 {{ if .Go -}}
@@ -47,6 +64,15 @@ $(GOLANGCI_LINT_BIN):
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
 	mv out/linters/golangci-lint $@
+
+LINTERS += golangci-lint-lint
+golangci-lint-lint: $(GOLANGCI_LINT_BIN)
+	{{ index .LintCommands "golangci-lint" }}
+
+FIXERS += golangci-lint-fix
+golangci-lint-fix: $(GOLANGCI_LINT_BIN)
+	{{ index .FixCommands "golangci-lint" }}
+
 {{ end -}}
 
 {{ if .YAML -}}
@@ -58,16 +84,17 @@ $(YAMLLINT_BIN):
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install --target dist .
+
+LINTERS += yamllint-lint
+yamllint-lint: $(YAMLLINT_BIN)
+	{{ .LintCommands.yamllint }}
+
 {{ end -}}
 
-.PHONY: _lint
-_lint: {{ if .Shell }}$(SHELLCHECK_BIN) {{ end }}{{ if .Dockerfile }}$(HADOLINT_BIN) {{ end }}{{ if .Go}}$(GOLANGCI_LINT_BIN) {{ end }}{{ if .YAML}}$(YAMLLINT_BIN){{ end }}
-	{{- range $k, $v := .LintCommands }}
-	{{ $v }}{{ end}}
+.PHONY: _lint $(LINTERS)
+_lint: $(LINTERS)
 
-.PHONY: fix
-fix: {{ if .Shell }}$(SHELLCHECK_BIN) {{ end }}{{ if .Go}}$(GOLANGCI_LINT_BIN){{ end }}
-	{{- range $k, $v := .FixCommands }}
-	{{ $v }}{{ end}}
+.PHONY: fix $(FIXERS)
+fix: $(FIXERS)
 
 # END: lint-install {{.Args}}

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -2,6 +2,9 @@
 # BEGIN: lint-install {{.Args}}
 # http://github.com/tinkerbell/lint-install
 
+.PHONY: lint
+lint: _lint
+
 {{ if .Go }}GOLINT_VERSION ?= v1.42.1{{ end }}
 {{ if .Dockerfile}}HADOLINT_VERSION ?= v2.7.0{{ end }}
 {{ if .Shell}}SHELLCHECK_VERSION ?= v0.7.2{{ end }}
@@ -20,16 +23,6 @@ endif
 
 {{ if .Go }}GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml{{ end }}
 {{ if .YAML }}YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION){{ end }}
-
-.PHONY: lint
-lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
-	{{- range .LintCommands }}
-	{{ .}}{{ end}}
-
-.PHONY: fix
-fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH){{ end }}
-	{{- range .FixCommands }}
-	{{ .}}{{ end}}
 
 {{ if .Shell -}}
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
@@ -63,5 +56,15 @@ $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
 {{ end -}}
+
+.PHONY: _lint
+_lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
+	{{- range .LintCommands }}
+	{{ .}}{{ end}}
+
+.PHONY: fix
+fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH){{ end }}
+	{{- range .FixCommands }}
+	{{ .}}{{ end}}
 
 # END: lint-install {{.Args}}

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -62,12 +62,12 @@ $(YAMLLINT_BIN):
 
 .PHONY: _lint
 _lint: {{ if .Shell }}$(SHELLCHECK_BIN) {{ end }}{{ if .Dockerfile }}$(HADOLINT_BIN) {{ end }}{{ if .Go}}$(GOLANGCI_LINT_BIN) {{ end }}{{ if .YAML}}$(YAMLLINT_BIN){{ end }}
-	{{- range .LintCommands }}
-	{{ .}}{{ end}}
+	{{- range $k, $v := .LintCommands }}
+	{{ $v }}{{ end}}
 
 .PHONY: fix
 fix: {{ if .Shell }}$(SHELLCHECK_BIN) {{ end }}{{ if .Go}}$(GOLANGCI_LINT_BIN){{ end }}
-	{{- range .FixCommands }}
-	{{ .}}{{ end}}
+	{{- range $k, $v := .FixCommands }}
+	{{ $v }}{{ end}}
 
 # END: lint-install {{.Args}}

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -17,45 +17,43 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
-
 {{ if .Shell -}}
 SHELLCHECK_VERSION ?= v0.7.2
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
-	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@
 	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
-
 {{ end -}}
+
 {{ if .Dockerfile -}}
 HADOLINT_VERSION ?= v2.7.0
 out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/hadolint-*
-	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
-	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
-
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > $@
+	chmod u+x $@
 {{ end -}}
+
 {{ if .Go -}}
-GOLANGCI_LINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.42.1
 out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
-	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
-
+	mv out/linters/golangci-lint $@
 {{ end -}}
 
 {{ if .YAML -}}
 YAMLLINT_VERSION ?= 1.26.3
-YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
+YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
 $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
-	cd $(YAMLLINT_ROOT) && pip3 install . -t dist
+	cd $(YAMLLINT_ROOT) && pip3 install --target dist .
 {{ end -}}
 
 .PHONY: _lint

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -5,10 +5,6 @@
 .PHONY: lint
 lint: _lint
 
-{{ if .Go }}GOLINT_VERSION ?= v1.42.1{{ end }}
-{{ if .Dockerfile}}HADOLINT_VERSION ?= v2.7.0{{ end }}
-{{ if .Shell}}SHELLCHECK_VERSION ?= v0.7.2{{ end }}
-{{ if .YAML}}YAMLLINT_VERSION ?= 1.26.3{{ end }}
 LINT_ARCH := $(shell uname -m)
 LINT_OS := $(shell uname)
 LINT_OS_LOWER := $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
@@ -21,10 +17,9 @@ ifeq ($(LINT_OS),Darwin)
 	endif
 endif
 
-{{ if .Go }}GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml{{ end }}
-{{ if .YAML }}YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION){{ end }}
 
 {{ if .Shell -}}
+SHELLCHECK_VERSION ?= v0.7.2
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
@@ -33,6 +28,7 @@ out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
 
 {{ end -}}
 {{ if .Dockerfile -}}
+HADOLINT_VERSION ?= v2.7.0
 out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/hadolint-*
@@ -41,6 +37,8 @@ out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 
 {{ end -}}
 {{ if .Go -}}
+GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+GOLINT_VERSION ?= v1.42.1
 out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
@@ -50,6 +48,8 @@ out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
 {{ end -}}
 
 {{ if .YAML -}}
+YAMLLINT_VERSION ?= 1.26.3
+YAMLLINT_ROOT = out/linters/yamllint-$(YAMLLINT_VERSION)
 $(YAMLLINT_ROOT)/dist/bin/yamllint:
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -20,11 +20,12 @@ endif
 
 {{ if .Shell -}}
 SHELLCHECK_VERSION ?= v0.7.2
-out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
+out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
-	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	rm -rf out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck
 
 {{ end -}}
 {{ if .Dockerfile -}}
@@ -58,12 +59,12 @@ $(YAMLLINT_ROOT)/dist/bin/yamllint:
 {{ end -}}
 
 .PHONY: _lint
-_lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
+_lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
 	{{- range .LintCommands }}
 	{{ .}}{{ end}}
 
 .PHONY: fix
-fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH){{ end }}
+fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH){{ end }}
 	{{- range .FixCommands }}
 	{{ .}}{{ end}}
 

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -21,7 +21,7 @@ LINTERS :=
 FIXERS :=
 
 {{ if .Shell -}}
-SHELLCHECK_VERSION ?= v0.7.2
+SHELLCHECK_VERSION ?= v0.8.0
 SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 $(SHELLCHECK_BIN):
 	mkdir -p out/linters
@@ -41,7 +41,7 @@ shellcheck-fix: $(SHELLCHECK_BIN)
 {{ end -}}
 
 {{ if .Dockerfile -}}
-HADOLINT_VERSION ?= v2.7.0
+HADOLINT_VERSION ?= v2.8.0
 HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 $(HADOLINT_BIN):
 	mkdir -p out/linters
@@ -57,7 +57,7 @@ hadolint-lint: $(HADOLINT_BIN)
 
 {{ if .Go -}}
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.42.1
+GOLANGCI_LINT_VERSION ?= v1.43.0
 GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p out/linters

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -37,13 +37,13 @@ out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 
 {{ end -}}
 {{ if .Go -}}
-GOLINT_CONFIG = $(LINT_ROOT)/.golangci.yml
-GOLINT_VERSION ?= v1.42.1
-out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+GOLANGCI_LINT_CONFIG = $(LINT_ROOT)/.golangci.yml
+GOLANGCI_LINT_VERSION ?= v1.42.1
+out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
-	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 
 {{ end -}}
 
@@ -58,12 +58,12 @@ $(YAMLLINT_ROOT)/dist/bin/yamllint:
 {{ end -}}
 
 .PHONY: _lint
-_lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
+_lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
 	{{- range .LintCommands }}
 	{{ .}}{{ end}}
 
 .PHONY: fix
-fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH){{ end }}
+fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH){{ end }}
 	{{- range .FixCommands }}
 	{{ .}}{{ end}}
 

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -19,7 +19,8 @@ endif
 
 {{ if .Shell -}}
 SHELLCHECK_VERSION ?= v0.7.2
-out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
+SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+$(SHELLCHECK_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/shellcheck-*
 	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
@@ -29,7 +30,8 @@ out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH):
 
 {{ if .Dockerfile -}}
 HADOLINT_VERSION ?= v2.7.0
-out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
+HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+$(HADOLINT_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/hadolint-*
 	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > $@
@@ -39,7 +41,8 @@ out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH):
 {{ if .Go -}}
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.42.1
-out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
+GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
+$(GOLANGCI_LINT_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/golangci-lint-*
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
@@ -49,7 +52,8 @@ out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH):
 {{ if .YAML -}}
 YAMLLINT_VERSION ?= 1.26.3
 YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
-$(YAMLLINT_ROOT)/dist/bin/yamllint:
+YAMLLINT_BIN := $(YAMLLINT_ROOT)/dist/bin/yamllint
+$(YAMLLINT_BIN):
 	mkdir -p out/linters
 	rm -rf out/linters/yamllint-*
 	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
@@ -57,12 +61,12 @@ $(YAMLLINT_ROOT)/dist/bin/yamllint:
 {{ end -}}
 
 .PHONY: _lint
-_lint: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Dockerfile }}out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) {{ end }}{{ if .YAML}}$(YAMLLINT_ROOT)/dist/bin/yamllint{{ end }}
+_lint: {{ if .Shell }}$(SHELLCHECK_BIN) {{ end }}{{ if .Dockerfile }}$(HADOLINT_BIN) {{ end }}{{ if .Go}}$(GOLANGCI_LINT_BIN) {{ end }}{{ if .YAML}}$(YAMLLINT_BIN){{ end }}
 	{{- range .LintCommands }}
 	{{ .}}{{ end}}
 
 .PHONY: fix
-fix: {{ if .Shell }}out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) {{ end }}{{ if .Go}}out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH){{ end }}
+fix: {{ if .Shell }}$(SHELLCHECK_BIN) {{ end }}{{ if .Go}}$(GOLANGCI_LINT_BIN){{ end }}
 	{{- range .FixCommands }}
 	{{ .}}{{ end}}
 

--- a/lint-install.go
+++ b/lint-install.go
@@ -255,10 +255,10 @@ func goLintCmd(root string, level string, fix bool) string {
 
 	klog.Infof("found %d modules within %s: %s", len(found), root, found)
 	if len(found) == 0 || (len(found) == 1 && found[0] == strings.Trim(root, "/")) {
-		return fmt.Sprintf("out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run%s", suffix)
+		return fmt.Sprintf("$(GOLANGCI_LINT_BIN) run%s", suffix)
 	}
 
-	return fmt.Sprintf(`find . -name go.mod -execdir "$(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
+	return fmt.Sprintf(`find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.
@@ -276,7 +276,7 @@ func shellLintCmd(_ string, level string, fix bool) string {
 		suffix = " || true"
 	}
 
-	return fmt.Sprintf(`out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) $(shell find . -name "*.sh")%s`, suffix)
+	return fmt.Sprintf(`$(SHELLCHECK_BIN) $(shell find . -name "*.sh")%s`, suffix)
 }
 
 // dockerLintCmd returns the appropriate docker lint command for a project.
@@ -286,7 +286,7 @@ func dockerLintCmd(_ string, level string) string {
 		f = " --no-fail"
 	}
 
-	return fmt.Sprintf(`out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)%s $(shell find . -name "*Dockerfile")`, f)
+	return fmt.Sprintf(`$(HADOLINT_BIN)%s $(shell find . -name "*Dockerfile")`, f)
 }
 
 // yamlLintCmd returns the appropriate yamllint command for a project.

--- a/lint-install.go
+++ b/lint-install.go
@@ -255,10 +255,10 @@ func goLintCmd(root string, level string, fix bool) string {
 
 	klog.Infof("found %d modules within %s: %s", len(found), root, found)
 	if len(found) == 0 || (len(found) == 1 && found[0] == strings.Trim(root, "/")) {
-		return fmt.Sprintf("out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run%s", suffix)
+		return fmt.Sprintf("out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH) run%s", suffix)
 	}
 
-	return fmt.Sprintf(`find . -name go.mod -execdir "$(LINT_ROOT)/out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
+	return fmt.Sprintf(`find . -name go.mod -execdir "$(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.

--- a/lint-install.go
+++ b/lint-install.go
@@ -276,7 +276,7 @@ func shellLintCmd(_ string, level string, fix bool) string {
 		suffix = " || true"
 	}
 
-	return fmt.Sprintf(`out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")%s`, suffix)
+	return fmt.Sprintf(`out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH) $(shell find . -name "*.sh")%s`, suffix)
 }
 
 // dockerLintCmd returns the appropriate docker lint command for a project.

--- a/lint-install.go
+++ b/lint-install.go
@@ -51,8 +51,8 @@ type Config struct {
 	Dockerfile   string
 	Shell        string
 	YAML         string
-	LintCommands []string
-	FixCommands  []string
+	LintCommands map[string]string
+	FixCommands  map[string]string
 }
 
 // applicableLinters returns a list of languages with known linters within a given directory.
@@ -317,14 +317,16 @@ func main() {
 		}
 
 		cfg := Config{
-			Args:     strings.Join(os.Args[1:], " "),
-			Makefile: *makeFileName,
+			Args:         strings.Join(os.Args[1:], " "),
+			Makefile:     *makeFileName,
+			LintCommands: make(map[string]string),
+			FixCommands:  make(map[string]string),
 		}
 
 		if needs[Go] {
 			cfg.Go = *goFlag
-			cfg.LintCommands = append(cfg.LintCommands, goLintCmd(root, cfg.Go, false))
-			cfg.FixCommands = append(cfg.FixCommands, goLintCmd(root, cfg.Go, true))
+			cfg.LintCommands["golangci-lint"] = goLintCmd(root, cfg.Go, false)
+			cfg.FixCommands["golangci-lint"] = goLintCmd(root, cfg.Go, true)
 
 			diff, err := updateFile(root, ".golangci.yml", goLintConfig, *dryRunFlag)
 			if err != nil {
@@ -348,16 +350,16 @@ func main() {
 		}
 		if needs[Dockerfile] {
 			cfg.Dockerfile = *dockerfileFlag
-			cfg.LintCommands = append(cfg.LintCommands, dockerLintCmd(root, cfg.Dockerfile))
+			cfg.LintCommands["hadolint"] = dockerLintCmd(root, cfg.Dockerfile)
 		}
 		if needs[Shell] {
 			cfg.Shell = *shellFlag
-			cfg.LintCommands = append(cfg.LintCommands, shellLintCmd(root, cfg.Shell, false))
-			cfg.FixCommands = append(cfg.FixCommands, shellLintCmd(root, cfg.Shell, true))
+			cfg.LintCommands["shellcheck"] = shellLintCmd(root, cfg.Shell, false)
+			cfg.FixCommands["shellcheck"] = shellLintCmd(root, cfg.Shell, true)
 		}
 		if needs[YAML] {
 			cfg.YAML = *yamlFlag
-			cfg.LintCommands = append(cfg.LintCommands, yamlLintCmd(root, cfg.Shell))
+			cfg.LintCommands["yamllint"] = yamlLintCmd(root, cfg.Shell)
 
 			diff, err := updateFile(root, ".yamllint", yamlLintConfig, *dryRunFlag)
 			if err != nil {

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+let _pkgs = import <nixpkgs> { };
+in { pkgs ? import (_pkgs.fetchFromGitHub {
+  owner = "NixOS";
+  repo = "nixpkgs";
+  #branch@date: nixpkgs-unstable@2021-11-12
+  rev = "2fbba4b4416446721ebfb2e0bfcc9e45d8ddb4d2";
+  sha256 = "1yw2p38pdvx63n21g6pmn79xjpxa93p1qpcadrlmg0j0zjnxkwr8";
+}) { } }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    git
+    gnumake
+    go
+    nixfmt
+    nodePackages.prettier
+    python3Packages.pip
+    python3Packages.setuptools
+    python3Packages.wheel
+  ];
+}


### PR DESCRIPTION
## Description

The main reason for this PR is to use make's concurrency features to run the lint/fix commands instead of doing so serially. The reason for wanting this is to be able to run `make --keep-going lint` so that we can see the errors for *all* linters instead of just one at a time, while still having make return an error exit if one of the linters did in fact fail.

There were some clean up/extras/fixes along the way including:

- Normalize shellcheck so the binary matches golangci-lint and hadolint (versioned binary name directly under out/linters)
- Update the dependencies to their latest released versions (2 reasons: 1 to get latest and greatest, 2 steps over issue with ^ if shellcheck was already downloaded)
- Adds nix-shell+direnv goodness
- Moves LINT_LOWER_OS out from just for shellcheck's use (seems like a good idea to have, also renamed to LINT_OS_LOWER so it groups with LINT_OS better)
- Reorganized the makefile so that there's only ever one `{{ if .$filetype }}` per file type. This just seems better to have everything per file-type in just one location instead of 2, 3, or 4.
- Renamed golangci-lint make variables to match the other variables, to include the full binary name
- Added $TOOL_BIN variable instead of writing the full path over and over. DRYness makes sense here.

## Why is this needed

The reason for wanting this is to be able to run `make --keep-going lint` so that we can see the errors for *all* linters instead of just one at a time, while still having make return an error exit if one of the linters did in fact fail.

## How Has This Been Tested?

I've run this locally, including `make fix`.

## How are existing users impacted? What migration steps/scripts do we need?

Less run-fix-check cycles since more of the errors are going to show up at once.
Newer linters with possibly better checks.