### PR TITLE
golangci-lint multi-module: Use $CURDIR to pin down execdir

### DIFF
--- a/lint-install.go
+++ b/lint-install.go
@@ -258,7 +258,7 @@ func goLintCmd(root string, level string, fix bool) string {
 		return fmt.Sprintf("$(GOLANGCI_LINT_BIN) run%s", suffix)
 	}
 
-	return fmt.Sprintf(`find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
+	return fmt.Sprintf(`find . -name go.mod -execdir "$(CURDIR)/$(GOLANGCI_LINT_BIN)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@chainguard.dev>

## Description

Fixes broken behavior with repositories containing multiple go packages. This change ensures that the successive find command are able to locate the path to golangci-lint properly. 
## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #39

## How Has This Been Tested?

Ran `make golangci-lint-lint` in a repo containing ~40 go packages

