### PR TITLE
Disable errorf option for errorlint.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,10 @@ linters-settings:
   errorlint:
     # these are still common in Go: for instance, exit errors.
     asserts: false
+    # Forcing %w in error wrapping forces authors to make errors part of their package APIs. The decision to make
+    # an error part of a package API should be a concious decision by the author.
+    # Also see Hyrums Law.
+    errorf: false
 
   exhaustive:
     default-signifies-exhaustive: true


### PR DESCRIPTION
The errorf option forces developers to expose errors as part of their
package APIs. This has the effect of forcing any use of a third party or
other package's errors to become part of a package API.

> Errors are part of [a] package API. If [an author is] forced to use %w it means [they're] forced to make all errors, whether [generated in the new code or not], part of the package API. That should really be a conscious decision by the author, not mandated by a linter.
>
> Hyrum's law comes into play because consumers become dependent on that error type and that was never intended making things harder to change in the future.

\- https://github.com/tinkerbell/hegel/pull/82#discussion_r852453070