### PR TITLE
Update to go 1.17

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,10 +88,10 @@ linters-settings:
       - name: waitgroup-by-value
 
   staticcheck:
-    go: "1.16"
+    go: "1.17"
 
   unused:
-    go: "1.16"
+    go: "1.17"
 
 output:
   sort-results: true

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/tinkerbell/lint-install
 
-go 1.16
+go 1.17
 
 require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/karrick/godirwalk v1.16.1
 	k8s.io/klog/v2 v2.10.0
 )
+
+require github.com/go-logr/logr v0.4.0 // indirect


### PR DESCRIPTION
As discussed in the community meeting: this updates the go.mod to use 1.17 keeping up-to-date with the times.