### PR TITLE
Fix golangci-lint linter when multiple modules exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ LINTERS :=
 FIXERS :=
 
 SHELLCHECK_VERSION ?= v0.8.0
-SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+SHELLCHECK_BIN := $(LINT_ROOT)/out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 $(SHELLCHECK_BIN):
-	mkdir -p out/linters
+	mkdir -p $(LINT_ROOT)/out/linters
 	curl -sSfL -o $@.tar.xz https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz \
 		|| echo "Unable to fetch shellcheck for $(LINT_OS)/$(LINT_ARCH): falling back to locally install"
 	test -f $@.tar.xz \
-		&& tar -C out/linters -xJf $@.tar.xz \
-		&& mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@ \
+		&& tar -C $(LINT_ROOT)/out/linters -xJf $@.tar.xz \
+		&& mv $(LINT_ROOT)/out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@ \
 		|| printf "#!/usr/bin/env shellcheck\n" > $@
 	chmod u+x $@
 
@@ -41,9 +41,9 @@ shellcheck-fix: $(SHELLCHECK_BIN)
 	$(SHELLCHECK_BIN) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
 HADOLINT_VERSION ?= v2.8.0
-HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+HADOLINT_BIN := $(LINT_ROOT)/out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 $(HADOLINT_BIN):
-	mkdir -p out/linters
+	mkdir -p $(LINT_ROOT)/out/linters
 	curl -sSfL -o $@.dl https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VERSION)/hadolint-$(LINT_OS)-$(LINT_ARCH) \
 		|| echo "Unable to fetch hadolint for $(LINT_OS)/$(LINT_ARCH), falling back to local install"
 	test -f $@.dl && mv $(HADOLINT_BIN).dl $@ || printf "#!/usr/bin/env hadolint\n" > $@
@@ -55,28 +55,28 @@ hadolint-lint: $(HADOLINT_BIN)
 
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.43.0
-GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
+GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
-	mkdir -p out/linters
-	rm -rf out/linters/golangci-lint-*
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
-	mv out/linters/golangci-lint $@
+	mkdir -p $(LINT_ROOT)/out/linters
+	rm -rf $(LINT_ROOT)/out/linters/golangci-lint-*
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LINT_ROOT)/out/linters $(GOLANGCI_LINT_VERSION)
+	mv $(LINT_ROOT)/out/linters/golangci-lint $@
 
 LINTERS += golangci-lint-lint
 golangci-lint-lint: $(GOLANGCI_LINT_BIN)
-	$(GOLANGCI_LINT_BIN) run
+	find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)" \;
 
 FIXERS += golangci-lint-fix
 golangci-lint-fix: $(GOLANGCI_LINT_BIN)
-	$(GOLANGCI_LINT_BIN) run --fix
+	find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)" --fix \;
 
 YAMLLINT_VERSION ?= 1.26.3
-YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
+YAMLLINT_ROOT := $(LINT_ROOT)/out/linters/yamllint-$(YAMLLINT_VERSION)
 YAMLLINT_BIN := $(YAMLLINT_ROOT)/dist/bin/yamllint
 $(YAMLLINT_BIN):
-	mkdir -p out/linters
-	rm -rf out/linters/yamllint-*
-	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
+	mkdir -p $(LINT_ROOT)/out/linters
+	rm -rf $(LINT_ROOT)/out/linters/yamllint-*
+	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C $(LINT_ROOT)/out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install --target dist . || pip install --target dist .
 
 LINTERS += yamllint-lint

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -22,14 +22,14 @@ FIXERS :=
 
 {{ if .Shell -}}
 SHELLCHECK_VERSION ?= v0.8.0
-SHELLCHECK_BIN := out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+SHELLCHECK_BIN := $(LINT_ROOT)/out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
 $(SHELLCHECK_BIN):
-	mkdir -p out/linters
+	mkdir -p $(LINT_ROOT)/out/linters
 	curl -sSfL -o $@.tar.xz https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz \
 		|| echo "Unable to fetch shellcheck for $(LINT_OS)/$(LINT_ARCH): falling back to locally install"
 	test -f $@.tar.xz \
-		&& tar -C out/linters -xJf $@.tar.xz \
-		&& mv out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@ \
+		&& tar -C $(LINT_ROOT)/out/linters -xJf $@.tar.xz \
+		&& mv $(LINT_ROOT)/out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $@ \
 		|| printf "#!/usr/bin/env shellcheck\n" > $@
 	chmod u+x $@
 
@@ -45,9 +45,9 @@ shellcheck-fix: $(SHELLCHECK_BIN)
 
 {{ if .Dockerfile -}}
 HADOLINT_VERSION ?= v2.8.0
-HADOLINT_BIN := out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
+HADOLINT_BIN := $(LINT_ROOT)/out/linters/hadolint-$(HADOLINT_VERSION)-$(LINT_ARCH)
 $(HADOLINT_BIN):
-	mkdir -p out/linters
+	mkdir -p $(LINT_ROOT)/out/linters
 	curl -sSfL -o $@.dl https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VERSION)/hadolint-$(LINT_OS)-$(LINT_ARCH) \
 		|| echo "Unable to fetch hadolint for $(LINT_OS)/$(LINT_ARCH), falling back to local install"
 	test -f $@.dl && mv $(HADOLINT_BIN).dl $@ || printf "#!/usr/bin/env hadolint\n" > $@
@@ -62,12 +62,12 @@ hadolint-lint: $(HADOLINT_BIN)
 {{ if .Go -}}
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
 GOLANGCI_LINT_VERSION ?= v1.43.0
-GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
+GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
-	mkdir -p out/linters
-	rm -rf out/linters/golangci-lint-*
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLANGCI_LINT_VERSION)
-	mv out/linters/golangci-lint $@
+	mkdir -p $(LINT_ROOT)/out/linters
+	rm -rf $(LINT_ROOT)/out/linters/golangci-lint-*
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LINT_ROOT)/out/linters $(GOLANGCI_LINT_VERSION)
+	mv $(LINT_ROOT)/out/linters/golangci-lint $@
 
 LINTERS += golangci-lint-lint
 golangci-lint-lint: $(GOLANGCI_LINT_BIN)
@@ -81,12 +81,12 @@ golangci-lint-fix: $(GOLANGCI_LINT_BIN)
 
 {{ if .YAML -}}
 YAMLLINT_VERSION ?= 1.26.3
-YAMLLINT_ROOT := out/linters/yamllint-$(YAMLLINT_VERSION)
+YAMLLINT_ROOT := $(LINT_ROOT)/out/linters/yamllint-$(YAMLLINT_VERSION)
 YAMLLINT_BIN := $(YAMLLINT_ROOT)/dist/bin/yamllint
 $(YAMLLINT_BIN):
-	mkdir -p out/linters
-	rm -rf out/linters/yamllint-*
-	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C out/linters -zxf -
+	mkdir -p $(LINT_ROOT)/out/linters
+	rm -rf $(LINT_ROOT)/out/linters/yamllint-*
+	curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VERSION).tar.gz | tar -C $(LINT_ROOT)/out/linters -zxf -
 	cd $(YAMLLINT_ROOT) && pip3 install --target dist . || pip install --target dist .
 
 LINTERS += yamllint-lint

--- a/lint-install.go
+++ b/lint-install.go
@@ -254,10 +254,6 @@ func goLintCmd(root string, level string, fix bool) string {
 	}
 
 	klog.Infof("found %d modules within %s: %s", len(found), root, found)
-	if len(found) == 0 || (len(found) == 1 && found[0] == strings.Trim(root, "/")) {
-		return fmt.Sprintf("$(GOLANGCI_LINT_BIN) run%s", suffix)
-	}
-
 	return fmt.Sprintf(`find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
 }
 

--- a/lint-install.go
+++ b/lint-install.go
@@ -254,7 +254,7 @@ func goLintCmd(root string, level string, fix bool) string {
 	}
 
 	klog.Infof("found %d modules within %s: %s", len(found), root, found)
-	return fmt.Sprintf(`find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLINT_CONFIG)"%s \;`, suffix)
+	return fmt.Sprintf(`find . -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)"%s \;`, suffix)
 }
 
 // shellLintCmd returns the appropriate shell lint command for a project.


### PR DESCRIPTION
## Description

* Uses full paths to executables, so changed dirs don't matter
* Switches to always using `find -execdir` to run golangci-lint to avoid an seldomly used corner case bit rotting
* Uses the correct variable name for the golangci-lint config file

## Why is this needed

Fixes: #39
Closes: #40 

## How Has This Been Tested?

Ran `make lint` a bunch in hook to make sure it works.

## How are existing users impacted? What migration steps/scripts do we need?

golangci-lint will actually run if multiple modules are detected (or added w/o having to re-run lint-install).
