### PR TITLE
Update to go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Build
         run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,10 +92,10 @@ linters-settings:
       - name: waitgroup-by-value
 
   staticcheck:
-    go: "1.17"
+    go: "1.18"
 
   unused:
-    go: "1.17"
+    go: "1.18"
 
 output:
   sort-results: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinkerbell/lint-install
 
-go 1.17
+go 1.18
 
 require (
 	github.com/hexops/gotextdiff v1.0.3

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@ let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
   repo = "nixpkgs";
-  #branch@date: nixpkgs-unstable@2021-11-12
-  rev = "2fbba4b4416446721ebfb2e0bfcc9e45d8ddb4d2";
-  sha256 = "1yw2p38pdvx63n21g6pmn79xjpxa93p1qpcadrlmg0j0zjnxkwr8";
+  #branch@date: nixpkgs-unstable@2022-08-17
+  rev = "d61d4e71ba9a8f56e9f2092b7cfa9cffa4253971";
+  sha256 = "0x76l64pchaqaw8v0b331g4jm3li1xcpkbwxpn9n6a769c4ynj58";
 }) { } }:
 
 with pkgs;
@@ -13,7 +13,7 @@ mkShell {
   buildInputs = [
     git
     gnumake
-    go
+    go_1_18
     nixfmt
     nodePackages.prettier
     python3Packages.pip


### PR DESCRIPTION
## Description

Update to Go 1.18

## Why is this needed

Go 1.19 has been released and Go 1.17 is now unsupported.
