### PR TITLE
golangci-lint update to v1.50.0, disable deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,6 @@ linters:
     - asciicheck
     - bodyclose
     - cyclop
-    - deadcode
     - dogsled
     - dupl
     - durationcheck
@@ -128,7 +127,6 @@ linters:
     - goprintffuncname
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - makezero
@@ -142,10 +140,10 @@ linters:
     # disabling for the initial iteration of the linting tool
     # - promlinter
     - revive
-    - rowserrcheck
-    - sqlclosecheck
+    # - rowserrcheck - disabled because of generics, https://github.com/golangci/golangci-lint/issues/2649
+    # - sqlclosecheck - disabled because of generics, https://github.com/golangci/golangci-lint/issues/2649
     - staticcheck
-    - structcheck
+    # - structcheck - disabled because of generics, https://github.com/golangci/golangci-lint/issues/2649
     - stylecheck
     - thelper
     - tparallel
@@ -153,8 +151,7 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
-    - wastedassign
+    # - wastedassign - disabled because of generics, https://github.com/golangci/golangci-lint/issues/2649
     - whitespace
 
   # Disabled linters, due to being misaligned with Go practices

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ hadolint-lint: $(HADOLINT_BIN)
 	$(HADOLINT_BIN) $(shell find . -name "*Dockerfile")
 
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.47.2
+GOLANGCI_LINT_VERSION ?= v1.50.0
 GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters

--- a/Makefile.tmpl
+++ b/Makefile.tmpl
@@ -61,7 +61,7 @@ hadolint-lint: $(HADOLINT_BIN)
 
 {{ if .Go -}}
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.47.2
+GOLANGCI_LINT_VERSION ?= v1.50.0
 GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Updates golangci-lint to v1.50.0.

This PR also removes deprecated linters, and adds comments to disable the ones which need to be updated to support generics.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally run.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
